### PR TITLE
Switch to sqlite3 for the backend disk-based queue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 json_minify
 lsl
 lwa_auth
+sqlite3
 zeroconf
 zmq

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ json_minify
 lsl
 lwa_auth
 sqlite3
-zeroconf
+netifaces
 zmq

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -916,8 +916,17 @@ class InterruptibleCopy(object):
         elif self.process.returncode < 0:
             self.status = 'paused'
         else:
-            smartCommonLogger.debug('copy failed -> %s', self.stderr.rstrip())
-            self.status = 'error: %s' % self.stderr
+            rsync_errors = []
+            for line in self.stdout.split('\n'):
+                if line.find('failed') != -1 or line.find('error') != -1:
+                    rsync_errors.append(line)
+                    
+            if rsync_errors:
+                error_message = '\n'.join(rsync_errors)
+                self.stderr = error_message + '\n' + self.stderr
+                
+            smartCommonLogger.debug('copy failed -> %s', self.stderr.strip())
+            self.status = 'error: %s' % self.stderr.strip()
             
         return self.process.returncode
         

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -248,7 +248,7 @@ class DiskBackedQueue(Queue.Queue):
                 # Insert with queue name
                 
                 self._cursor.execute(
-                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry, last_try) 
+                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try) 
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
@@ -325,7 +325,7 @@ class DiskBackedQueue(Queue.Queue):
                 # Insert with queue name
                 
                 self._cursor.execute(
-                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry, last_try, status) 
+                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
@@ -390,7 +390,7 @@ class DiskBackedQueue(Queue.Queue):
                 # Insert with queue name
                 
                 self._cursor.execute(
-                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry, last_try, status) 
+                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -81,7 +81,7 @@ class LimitedSizeDict(OrderedDict):
                 self.popitem(last=False)
 
 
-class DiskBackedQueue(queue.Queue):
+class DiskBackedQueue(Queue.Queue):
     """
     A thread-safe FIFO queue that persists items to disk using SQLite,
     supporting multiple queues in a single database.
@@ -113,8 +113,8 @@ class DiskBackedQueue(queue.Queue):
 
     # Class-level connection management
     _db_lock = threading.RLock()
-    _conn: Optional[sqlite3.Connection] = None
-    _cursor: Optional[sqlite3.Cursor] = None
+    _conn = None
+    _cursor = None
     _ref_count: int = 0
 
     @classmethod
@@ -340,9 +340,9 @@ class DiskBackedQueue(queue.Queue):
                 
     def get_completed(self):
         """Return a list of completed files as a three-element tuples containing
-         host, host path, and file size."""
-         with self._lock:
-             try:
+        host, host path, and file size."""
+        with self._lock:
+            try:
                 self._cursor.execute(
                     """SELECT host, hostpath, filesize
                        FROM queue_items
@@ -355,7 +355,7 @@ class DiskBackedQueue(queue.Queue):
             except sqlite3.Error as e:
                 logger.error(f"Failed to get completed files for {self.queue_name}: {e}")
                 raise
-                
+                    
     def purge_completed(self):
         """Remove all completed files from the queue."""
         with self._lock:
@@ -405,9 +405,9 @@ class DiskBackedQueue(queue.Queue):
                 
     def get_failed(self):
         """Return a list of failed files as a four-element tuples containing
-         host, host path, failure reason, and file size."""
-         with self._lock:
-             try:
+        host, host path, failure reason, and file size."""
+        with self._lock:
+            try:
                 self._cursor.execute(
                     """SELECT host, hostpath, destpath, filesize
                        FROM queue_items

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -223,8 +223,8 @@ class DiskBackedQueue(Queue.Queue):
                 
                 for row in rows:
                     try:
-                        super().put(*row)
-                        self.restored_items.append(*row)
+                        super().put(row)
+                        self.restored_items.append(row)
                     except (pickle.UnpicklingError, EOFError) as e:
                         smartCommonLogger.warning(f"Failed to restore queue item in {self.queue_name}: {e}")
                 

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -12,12 +12,13 @@ import threading
 import traceback
 import subprocess
 import logging
+import sqlite3
 from io import StringIO
 from socket import gethostname
 
 from collections import OrderedDict
 
-__version__ = '0.3'
+__version__ = '0.4'
 __all__ = ['SerialNumber', 'LimitedSizeDict', 'DiskBackedQueue', 
            'InterruptibleCopy', 'DELETE_MARKER_QUEUE', 'DELETE_MARKER_NOW']
 
@@ -80,85 +81,263 @@ class LimitedSizeDict(OrderedDict):
                 self.popitem(last=False)
 
 
-class DiskBackedQueue(Queue.Queue):
+class DiskBackedQueue(queue.Queue):
     """
-    Sub-class of Queue.Queue that keeps a copy of the FIFO queue on-disk to 
-    insure continuity between power outages.
+    A thread-safe FIFO queue that persists items to disk using SQLite,
+    supporting multiple queues in a single database.
     """
     
-    _sep = b'<<%>>'
+    SCHEMA = """
+    PRAGMA journal_mode=WAL;
+    PRAGMA synchronous=FULL;
+    PRAGMA busy_timeout=5000;
     
-    def __init__(self, filename, maxsize=0, restore=True):
-        self._filename = filename
-        self._lock = threading.RLock()
-        Queue.Queue.__init__(self, maxsize=maxsize)
-        
-        # See if we need to restore from disk
-        self.restored = []
-        with self._lock:
-            if restore:
-                if os.path.exists(self._filename):
-                    if os.path.getsize(self._filename) > 0:
-                        with open(self._filename, 'rb') as fh:
-                            contents = fh.read()
-                        contents = contents.split(self._sep)
-                        for i,entry in enumerate(contents):
-                            try:
-                                item = pickle.loads(entry)
-                                ## Try to avoid ID collisions across restarts
-                                ## NOTE:  This is particullarly clean since
-                                ##        it doesn't update the ID in the file
-                                host, hostpath, dest, destpath, id, retries, lasttry = item
-                                if not isinstance(id, int):
-                                    id = int(id, 10)
-                                if id < 1024:
-                                    id += 1024
-                                    item = (host, hostpath, dest, destpath, id, retries, lasttry)
-                                Queue.Queue.put(self, item)
-                                self.restored.append(item)
-                            except Exception as e:
-                                warnings.warn("Failed to load entry %i of '%s': %s" \
-                                              % (i, os.path.basename(self._filename), str(e)),
-                                              RuntimeWarning)
-            else:
+    CREATE TABLE IF NOT EXISTS queue_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        queue_name TEXT NOT NULL,
+        item BLOB NOT NULL,
+        status TEXT DEFAULT 'pending',
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        checksum TEXT NOT NULL
+    );
+    
+    CREATE INDEX IF NOT EXISTS idx_queue_status ON queue_items(queue_name, status);
+    CREATE INDEX IF NOT EXISTS idx_created ON queue_items(created_at);
+    """
+
+    # Class-level connection management
+    _db_lock = threading.RLock()
+    _conn: Optional[sqlite3.Connection] = None
+    _cursor: Optional[sqlite3.Cursor] = None
+    _ref_count: int = 0
+
+    @classmethod
+    def _get_connection(cls, db_file):
+        """Get or create the shared database connection."""
+        with cls._db_lock:
+            if cls._conn is None:
                 try:
-                    os.unlink(self._filename)
-                except OSError:
+                    # Initialize the connection
+                    os.makedirs(os.path.dirname(os.path.abspath(db_file)), exist_ok=True)
+                    cls._conn = sqlite3.connect(
+                        db_file,
+                        isolation_level='IMMEDIATE',
+                        check_same_thread=False,
+                        timeout=30.0
+                    )
+                    cls._cursor = cls._conn.cursor()
+                    cls._cursor.executescript(cls.SCHEMA)
+                    cls._conn.commit()
+                except sqlite3.Error as e:
+                    smartCommonLogger.error(f"Failed to initialize queue database: {e}")
+                    raise
+            
+            cls._ref_count += 1
+            return cls._conn, cls._cursor
+
+    @classmethod
+    def _release_connection(cls):
+        """Release the shared database connection."""
+        with cls._db_lock:
+            cls._ref_count -= 1
+            if cls._ref_count == 0 and cls._conn is not None:
+                try:
+                    cls._conn.commit()
+                    cls._conn.close()
+                    cls._conn = None
+                    cls._cursor = None
+                except sqlite3.Error:
                     pass
-                    
-    def _queue_file_io(self, put=None, task_done=False):
+
+    def __init__(self, filename, queue_name, maxsize=0, restore=True):
+        """
+        Initialize a queue instance.
+        
+        Args:
+            filename: Shared SQLite database file path
+            queue_name: Unique name for this queue (e.g., 'DR1', 'DR2')
+            maxsize: Maximum queue size (0 = unlimited)
+            restore: Whether to restore pending items on startup
+        """
+        super().__init__(maxsize)
+        
+        self._db_file = filename
+        self.queue_name = queue_name
+        self._lock = threading.RLock()
+        
+        self.restored_items = []
+        
+        # Get shared database connection
+        self._conn, self._cursor = self._get_connection(filename)
+        
+        # Verify queue integrity
+        self._check_integrity()
+        
+        # Restore pending items if requested
+        if restore:
+            self._restore_pending_items()
+
+    def _check_integrity(self):
+        """Verify queue integrity and recover if needed."""
         with self._lock:
             try:
-                with open(self._filename, 'rb') as fh:
-                    contents = fh.read()
-                contents = contents.split(self._sep)
-            except (OSError, IOError):
-                contents = []
-                
-            if put is not None:
-                put = pickle.dumps(put, protocol=0)
-                contents.insert(0, put)
-                with open(self._filename, 'wb') as fh:
-                    fh.write(self._sep.join(contents))
-            elif task_done:
-                contents = contents[:-1]
-                with open(self._filename, 'wb') as fh:
-                    fh.write(self._sep.join(contents))
+                # Check for and recover from interrupted transactions
+                self._cursor.execute(
+                    """SELECT COUNT(*) FROM queue_items 
+                       WHERE queue_name = ? AND status = 'processing'""",
+                    (self.queue_name,)
+                )
+                processing_count = self._cursor.fetchone()[0]
+                if processing_count > 0:
+                    smartCommonLogger.warning(
+                        f"Found {processing_count} interrupted transactions for {self.queue_name}, recovering..."
+                    )
+                    self._cursor.execute(
+                        """UPDATE queue_items SET status = 'pending' 
+                           WHERE queue_name = ? AND status = 'processing'""",
+                        (self.queue_name,)
+                    )
+                    self._conn.commit()
                     
+            except sqlite3.Error as e:
+                smartCommonLogger.error(f"Integrity check failed for {self.queue_name}: {e}")
+                raise
+
+    def _restore_pending_items(self):
+        """Restore pending items from the database to memory."""
+        with self._lock:
+            try:
+                self._cursor.execute(
+                    """SELECT item FROM queue_items 
+                       WHERE queue_name = ? AND status = 'pending' 
+                       ORDER BY id""",
+                    (self.queue_name,)
+                )
+                rows = self._cursor.fetchall()
+                
+                for row in rows:
+                    try:
+                        item = pickle.loads(row[0])
+                        super().put(item)
+                        self.restored_items.append(item)
+                    except (pickle.UnpicklingError, EOFError) as e:
+                        smartCommonLogger.warning(f"Failed to restore queue item in {self.queue_name}: {e}")
+                
+                smartCommonLogger.info(f"Restored {len(self.restored_items)} items for {self.queue_name}")
+                
+            except sqlite3.Error as e:
+                smartCommonLogger.error(f"Failed to restore items for {self.queue_name}: {e}")
+                raise
+
     def put(self, item, block=True, timeout=None):
+        """Put an item into the queue."""
         with self._lock:
-            Queue.Queue.put(self, item, block=block, timeout=timeout)
-            self._queue_file_io(put=item)
+            super().put(item, block, timeout)
             
-    def put_nowait(self, item):
+            try:
+                # Start transaction
+                self._cursor.execute("BEGIN IMMEDIATE")
+                
+                # Serialize item and compute checksum
+                pickled_item = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+                checksum = str(hash(pickled_item))
+                
+                # Insert with queue name
+                self._cursor.execute(
+                    """INSERT INTO queue_items (queue_name, item, checksum) 
+                       VALUES (?, ?, ?)""",
+                    (self.queue_name, pickled_item, checksum)
+                )
+                
+                # Commit transaction
+                self._conn.commit()
+                
+            except sqlite3.Error as e:
+                self._conn.rollback()
+                smartCommonLogger.error(f"Failed to persist queue item for {self.queue_name}: {e}")
+                raise
+
+    def get(self, block=True, timeout=None):
+        """Get an item from the queue."""
         with self._lock:
-            Queue.Queue.put_nowait(self, item)
-            self._queue_file_io(put=item)
+            item = super().get(block, timeout)
             
+            try:
+                # Start transaction
+                self._cursor.execute("BEGIN IMMEDIATE")
+                
+                pickled_item = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+                checksum = str(hash(pickled_item))
+                
+                self._cursor.execute(
+                    """UPDATE queue_items 
+                       SET status = 'processing' 
+                       WHERE queue_name = ? AND item = ? AND checksum = ? 
+                       AND status = 'pending'""",
+                    (self.queue_name, pickled_item, checksum)
+                )
+                
+                # Commit transaction
+                self._conn.commit()
+                
+            except sqlite3.Error as e:
+                self._conn.rollback()
+                smartCommonLogger.error(f"Failed to update queue item status for {self.queue_name}: {e}")
+                raise
+                
+            return item
+
     def task_done(self):
+        """Mark task as done."""
         with self._lock:
-            Queue.Queue.task_done(self)
-            self._queue_file_io(task_done=True)
+            super().task_done()
+            
+            try:
+                # Start transaction
+                self._cursor.execute("BEGIN IMMEDIATE")
+                
+                # Remove completed items for this queue
+                self._cursor.execute(
+                    """DELETE FROM queue_items 
+                       WHERE queue_name = ? AND status = 'processing'""",
+                    (self.queue_name,)
+                )
+                
+                # Commit transaction
+                self._conn.commit()
+                
+            except sqlite3.Error as e:
+                self._conn.rollback()
+                smartCommonLogger.error(f"Failed to mark queue item as done for {self.queue_name}: {e}")
+                raise
+
+    def get_queue_stats(self):
+        """Get statistics about this queue."""
+        with self._lock:
+            try:
+                stats = {
+                    'pending': 0,
+                    'processing': 0,
+                    'failed': 0
+                }
+                
+                self._cursor.execute(
+                    """SELECT status, COUNT(*) FROM queue_items 
+                       WHERE queue_name = ? GROUP BY status""",
+                    (self.queue_name,)
+                )
+                for status, count in self._cursor.fetchall():
+                    stats[status] = count
+                    
+                return stats
+                
+            except sqlite3.Error as e:
+                smartCommonLogger.error(f"Failed to get queue statistics for {self.queue_name}: {e}")
+                raise
+
+    def __del__(self):
+        """Release the shared connection."""
+        self._release_connection()
 
 
 class InterruptibleCopy(object):

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -316,7 +316,7 @@ class DiskBackedQueue(Queue.Queue):
     def add_completed(self, host, hostpath, filesize=0):
         """A file as successfully completed."""
         with self._lock:
-            item = (host, hostpath, host, hostpath, filesize, 0, time.time(), 'completed')
+            item = (host, hostpath, host, hostpath, filesize, -1, 0, time.time(), 'completed')
             
             try:
                 # Start transaction
@@ -325,8 +325,8 @@ class DiskBackedQueue(Queue.Queue):
                 # Insert with queue name
                 
                 self._cursor.execute(
-                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, filesize, command_id, retry_count, last_try, status) 
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
                 
@@ -381,7 +381,7 @@ class DiskBackedQueue(Queue.Queue):
     def add_failed(self, host, hostpath, reason='', filesize=0):
         """A file as failed."""
         with self._lock:
-            item = (host, hostpath, host, reason, filesize, 0, time.time(), 'failed')
+            item = (host, hostpath, host, reason, filesize, 0, -2, time.time(), 'failed')
             
             try:
                 # Start transaction
@@ -390,8 +390,8 @@ class DiskBackedQueue(Queue.Queue):
                 # Insert with queue name
                 
                 self._cursor.execute(
-                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, filesize, command_id, retry_count, last_try, status) 
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
                 

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -326,7 +326,7 @@ class DiskBackedQueue(Queue.Queue):
                 
                 self._cursor.execute(
                     """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
                 
@@ -391,7 +391,7 @@ class DiskBackedQueue(Queue.Queue):
                 
                 self._cursor.execute(
                     """INSERT INTO queue_items (queue_name, host, hostpath, dest, destpath, command_id, retry_count, last_try, status) 
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (self.queue_name, *item)
                 )
                 

--- a/smartCommon.py
+++ b/smartCommon.py
@@ -880,7 +880,7 @@ class InterruptibleCopy(object):
                         break
                 else:
                     break
-             while watchErr.poll(1):
+            while watchErr.poll(1):
                 if self.process.poll() is None:
                     try:
                         new_text = self.process.stderr.read(1)

--- a/smartCopy.py
+++ b/smartCopy.py
@@ -123,6 +123,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartCopy.py
+++ b/smartCopy.py
@@ -11,7 +11,7 @@ import argparse
 import subprocess
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 #
 # Site Name
@@ -25,6 +25,23 @@ MCS_RCV_BYTES = 16*1024
 
 # Regular expresion to check for remote paths
 REMOTE_PATH_RE = re.compile(r'^((?P<user>[a-zA-Z0-9]+)\@)?(?P<host>[a-zA-Z0-9\-]+)(?<!\\)\:')
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def getTime():
@@ -98,46 +115,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -209,9 +197,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -227,4 +212,3 @@ if __name__ == "__main__":
                         help='display version information')
     args = parser.parse_args()
     main(args)
-    

--- a/smartCopyHelper.py
+++ b/smartCopyHelper.py
@@ -11,7 +11,7 @@ import argparse
 import subprocess
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 from lsl.common import sdf, mcs, metabundle, metabundleADP
 
@@ -19,6 +19,23 @@ from lsl.common import sdf, mcs, metabundle, metabundleADP
 # Site Name
 #
 SITE = socket.gethostname().split('-', 1)[0]
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def doesUserDirectoryExist(destUser):
@@ -189,46 +206,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -396,9 +384,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -422,4 +407,3 @@ if __name__ == "__main__":
     else:
         args.observations = [int(v,10)-1 for v in args.observations.split(',')]
     main(args)
-    

--- a/smartCopyHelper.py
+++ b/smartCopyHelper.py
@@ -214,6 +214,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartCopyLeo.py
+++ b/smartCopyLeo.py
@@ -203,6 +203,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartCopyLeo.py
+++ b/smartCopyLeo.py
@@ -11,7 +11,7 @@ import argparse
 import subprocess
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 from lsl.common import mcs, metabundle, metabundleADP
 
@@ -23,6 +23,23 @@ DEFAULT_PATH = '/data2/from_%s/' % SITE
 
 
 _usernameRE = re.compile(r'ucfuser:[ \t]*(?P<username>[a-zA-Z1]+)(\/(?P<subdir>[a-zA-Z0-9\/\+\-_]+))?')
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def parseMetadata(tarname):
@@ -178,46 +195,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -326,9 +314,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -356,4 +341,3 @@ if __name__ == "__main__":
     else:
         args.allowed_projects = [v for v in args.allowed_projects.split(',')]
     main(args)
-    

--- a/smartCopyPause.py
+++ b/smartCopyPause.py
@@ -8,7 +8,7 @@ import socket
 import argparse
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 #
 # Site Name
@@ -18,6 +18,23 @@ SITE = socket.gethostname().split('-', 1)[0]
 
 # Maximum number of bytes to receive from MCS
 MCS_RCV_BYTES = 16*1024
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def getTime():
@@ -84,46 +101,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     cmds = []
     nDR = 5 if SITE == 'lwa1' else 4
     for i in range(1, nDR+1):
@@ -157,9 +145,6 @@ def main(args):
         sockOut.close()
     except socket.error as e:
         raise RuntimeError(str(e))
-        
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -185,4 +170,3 @@ if __name__ == "__main__":
                         help='display version information')
     args = parser.parse_args()
     main(args)
-    

--- a/smartCopyPause.py
+++ b/smartCopyPause.py
@@ -109,6 +109,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartCopyResume.py
+++ b/smartCopyResume.py
@@ -108,6 +108,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartCopyResume.py
+++ b/smartCopyResume.py
@@ -7,7 +7,7 @@ import socket
 import argparse
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 #
 # Site Name
@@ -17,6 +17,23 @@ SITE = socket.gethostname().split('-', 1)[0]
 
 # Maximum number of bytes to receive from MCS
 MCS_RCV_BYTES = 16*1024
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def getTime():
@@ -83,46 +100,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+   # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     cmds = []
     nDR = 5 if SITE == 'lwa1' else 4
     for i in range(1, nDR+1):
@@ -156,9 +144,6 @@ def main(args):
         sockOut.close()
     except socket.error as e:
         raise RuntimeError(str(e))
-        
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -184,4 +169,3 @@ if __name__ == "__main__":
                         help='display version information')
     args = parser.parse_args()
     main(args)
-    

--- a/smartDelete.py
+++ b/smartDelete.py
@@ -117,6 +117,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartDelete.py
+++ b/smartDelete.py
@@ -9,7 +9,7 @@ import socket
 import argparse
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 #
 # Site Name
@@ -19,6 +19,23 @@ SITE = socket.gethostname().split('-', 1)[0]
 
 # Maximum number of bytes to receive from MCS
 MCS_RCV_BYTES = 16*1024
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    #raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def getTime():
@@ -92,46 +109,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -191,9 +179,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -209,4 +194,3 @@ if __name__ == "__main__":
                         help='request that the delete(s) be executed as soon as the command(s) reach the front of the queue')
     args = parser.parse_args()
     main(args)
-    

--- a/smartDeleteHelper.py
+++ b/smartDeleteHelper.py
@@ -197,6 +197,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartDeleteHelper.py
+++ b/smartDeleteHelper.py
@@ -11,7 +11,7 @@ import argparse
 import subprocess
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 from lsl.common import sdf, mcs, metabundle, metabundleADP
 
@@ -19,6 +19,23 @@ from lsl.common import sdf, mcs, metabundle, metabundleADP
 # Site Name
 #
 SITE = socket.gethostname().split('-', 1)[0]
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def parseMetadata(tarname):
@@ -172,46 +189,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -316,9 +304,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":

--- a/smartFunctions.py
+++ b/smartFunctions.py
@@ -60,7 +60,6 @@ class SmartCopy(object):
         ## Monitoring and background threads (antenna statistics, flags, etc.)
         self.currentState['pollingThread'] = None
         self.currentState['drThreads'] = None
-        self.currentState['errorThread'] = None
         
     def getState(self):
         """
@@ -124,7 +123,6 @@ class SmartCopy(object):
             self.currentState['drThreads'][dr].start()
             self.resumeCopyQueue(dr, internal=True)
         self.currentState['pollingThread'].start()
-        self.currentState['errorThread'].start()
         
         self.currentState['status'] = 'NORMAL'
         self.currentState['info'] = 'System calibrated and operating normally'

--- a/smartFunctions.py
+++ b/smartFunctions.py
@@ -118,12 +118,7 @@ class SmartCopy(object):
                 dr = 'DR%i' % i
                 self.currentState['drThreads'][dr] = ManageDR(dr, self.config, SCCallbackInstance=self)
                 self.globalInhibit[dr] = True
-        ## Error log monitor
-        if self.currentState['errorThread'] is not None:
-            self.currentState['errorThread'].stop()
-        else:
-            self.currentState['errorThread'] = MonitorErrorLogs(self.config)
-            
+                
         # Start all threads back up
         for dr in self.currentState['drThreads']:
             self.currentState['drThreads'][dr].start()
@@ -180,10 +175,7 @@ class SmartCopy(object):
             for dr in self.currentState['drThreads']:
                 self.pauseCopyQueue(dr, internal=True)
                 self.currentState['drThreads'][dr].stop()
-        ## Error log monitor
-        if self.currentState['errorThread'] is not None:
-            self.currentState['errorThread'].stop()
-            
+                
         self.currentState['status'] = 'SHUTDWN'
         self.currentState['info'] = 'System has been shut down'
         self.currentState['lastLog'] = 'System has been shut down'
@@ -382,6 +374,30 @@ class SmartCopy(object):
                 status, value = self.currentState['drThreads'][dr].getQueueSize()
                 if not status:
                     self.currentState['lastLog'] = 'QUEUE: error getting queue size'
+                    return False, 0
+                else:
+                    return True, value
+            except KeyError:
+                self.currentState['lastLog'] = 'QUEUE: unknown data recorder %s' % dr
+                return False, 0
+                
+    def getDRQueueStats(self):
+        """
+        Return the queue status (pending, processing, completed, failed) of the
+        specified data recorder.  Return a two-element tuple of (success, value)
+        where success is a boolean related to if the size was found.  See the
+        currentState['lastLog'] entry for the reason for failure if the returned
+        success value is False.
+        """
+        
+        if self.currentState['drThreads'] is None:
+            self.currentState['lastLog'] = 'QUEUE: data recorder monitoring threads are not running'
+            return False, 0
+        else:
+            try:
+                status, value = self.currentState['drThreads'][dr].getQueueStats()
+                if not status:
+                    self.currentState['lastLog'] = 'QUEUE: error getting queue stats'
                     return False, 0
                 else:
                     return True, value

--- a/smartFunctions.py
+++ b/smartFunctions.py
@@ -379,7 +379,7 @@ class SmartCopy(object):
                 self.currentState['lastLog'] = 'QUEUE: unknown data recorder %s' % dr
                 return False, 0
                 
-    def getDRQueueStats(self):
+    def getDRQueueStats(self, dr):
         """
         Return the queue status (pending, processing, completed, failed) of the
         specified data recorder.  Return a two-element tuple of (success, value)

--- a/smartQuery.py
+++ b/smartQuery.py
@@ -10,7 +10,7 @@ import socket
 import argparse
 from datetime import datetime
 
-from zeroconf import Zeroconf
+import netifaces
 
 #
 # Site Name
@@ -20,6 +20,23 @@ SITE = socket.gethostname().split('-', 1)[0]
 
 # Maximum number of bytes to receive from MCS
 MCS_RCV_BYTES = 16*1024
+
+
+def getServerAddress():
+    """
+    Return the IP address of the smart copy server by looking for an interface
+    on a 10.1.x.0 network.
+    """
+    
+    for interface in netifaces.interfaces():
+        addrs = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addrs:
+            for addr in addrs[netifaces.AF_INET]:
+                ip = addr['addr']
+                if ip.startswith('10.1.'):
+                    network = '.'.join(ip.split('.')[:3])
+                    return f"{network}.2"
+    raise RuntimeError("Could not find 10.1.x.0 network interface")
 
 
 def getTime():
@@ -93,46 +110,17 @@ def parsePayload(payload):
 
 
 def main(args):
-    # Connect to the smart copy command server
-    tPoll = time.time()
-    nametag = SITE.replace('lwa', '').lower()
-    zinfo = None
-    while time.time() - tPoll <= 10.0:
-        zeroconf = Zeroconf()
-        zinfo = zeroconf.get_service_info("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag)
-        
-        if zinfo is not None:
-            if 'message_out_port' not in zinfo.properties \
-               and b'message_out_port' not in zinfo.properties:
-                zinfo = None
-                
-        if zinfo is not None:
-            break
-            
-        zeroconf.close()
-        time.sleep(1)
-    if zinfo is None:
-        raise RuntimeError("Cannot find the smart copy command server")
-        
-    try:
-        outHost = socket.inet_ntoa(zinfo.addresses[0])
-    except AttributeError:
-        outHost = socket.inet_ntoa(zinfo.address)
-    outPort = zinfo.port
+    # Find the smart copy command server and set the in/out ports
+    outHost = getServerAddress()
+    outPort = 5050
     try:
         inHost = socket.gethostname().split('-')[1].upper()
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
-    while len(inHost) < 3:
-        inHost += "_"
-    try:
-        inPort = int(zinfo.properties['message_out_port'], 10)
-        refPort = int(zinfo.properties['message_ref_port'], 10)
-    except KeyError:
-        inPort = int(zinfo.properties[b'message_out_port'], 10)
-        refPort = int(zinfo.properties[b'message_ref_port'], 10)
-        
+    inPort = 5051
+    refPort = 5052
+    
     context = zmq.Context()
     sockRef = context.socket(zmq.REQ)
     sockRef.connect("tcp://%s:%i" % (outHost, refPort))
@@ -175,9 +163,6 @@ def main(args):
         
     sockRef.close()
     context.term()
-    
-    zeroconf.close()
-    time.sleep(0.1)
 
 
 if __name__ == "__main__":
@@ -209,4 +194,3 @@ if __name__ == "__main__":
                         help='display version information')
     args = parser.parse_args()
     main(args)
-    

--- a/smartQuery.py
+++ b/smartQuery.py
@@ -168,10 +168,11 @@ def main(args):
 if __name__ == "__main__":
     def mib(value):
         _queryRE = re.compile(r'(?P<name>[A-Z_]+)(?P<number>\d+)')
-        _valid_names = ['OBSSTATUS_DR', 'QUEUE_SIZE_DR', 'QUEUE_STATUS_DR',
-                        'QUEUE_ENTRY_', 'ACTIVE_ID_DR', 'ACTIVE_STATUS_DR',
-                        'ACTIVE_BYTES_DR', 'ACTIVE_PROGRESS_DR', 
-                        'ACTIVE_SPEED_DR', 'ACTIVE_REMAINING_DR']
+        _valid_names = ['OBSSTATUS_DR', 'QUEUE_SIZE_DR', 'QUEUE_STATS_DR',
+                        'QUEUE_STATUS_DR', 'QUEUE_ENTRY_', 'ACTIVE_ID_DR',
+                        'ACTIVE_STATUS_DR', 'ACTIVE_BYTES_DR',
+                        'ACTIVE_PROGRESS_DR', 'ACTIVE_SPEED_DR',
+                        'ACTIVE_REMAINING_DR']
         mtch = _queryRE.match(value)
         if mtch is None:
             _valid_names = ['SUMMARY', 'INFO', 'LASTLOG', 'SUBSYSTEM',

--- a/smartQuery.py
+++ b/smartQuery.py
@@ -158,10 +158,12 @@ def main(args):
                 for line in info:
                     print("  %s" % line)
                     
-        sockIn.close()
-        sockOut.close()
     except socket.error as e:
         raise RuntimeError(str(e))
+        
+    finally:
+        sockIn.close()
+        sockOut.close()
         
     sockRef.close()
     context.term()

--- a/smartQuery.py
+++ b/smartQuery.py
@@ -118,6 +118,8 @@ def main(args):
     except IndexError:
         inHost = socket.gethostname().upper()
     inHost = inHost[:3]
+    while len(inHost) < 3:
+        inHost += "_"
     inPort = 5051
     refPort = 5052
     

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -703,7 +703,7 @@ class ManageDR(object):
             ### The report
             msg = MIMEText(report)
             msg['Subject'] = 'Recent SmartCopy Failures  for %s - %s' % (self.dr, datetime.utcnow().strftime("%Y/%m/%d"),)
-            msg['From'] = self.FROM
+            msg['From'] = self.config['email']['username']
             msg['To'] = ','.join(to)
             if cc is not None:
                 cc = list(set(cc))
@@ -718,10 +718,10 @@ class ManageDR(object):
                 
             ## Send it off
             try:
-                server = smtplib.SMTP(self.ESRV, 587)
+                server = smtplib.SMTP(self.config['email']['smtp_server'], 587)
                 server.starttls()
-                server.login(self.FROM, self.PASS)
-                server.sendmail(self.FROM, rcpt, msg.as_string())
+                server.login(self.config['email']['username'], self.config['email']['password'])
+                server.sendmail(self.config['email']['username'], rcpt, msg.as_string())
                 server.close()
             except Exception as e:
                 smartThreadsLogger.error("Could not send error report e-mail: %s", str(e))

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -23,8 +23,8 @@ from lwa_auth import STORE as LWA_AUTH_STORE
 
 from smartCommon import *
 
-__version__ = "0.6"
-__all__ = ['MonitorStation', 'ManageDR', 'MonitorErrorLogs']
+__version__ = "0.7"
+__all__ = ['MonitorStation', 'ManageDR']
 
 
 smartThreadsLogger = logging.getLogger('__main__')
@@ -387,14 +387,16 @@ class ManageDR(object):
                                 if self.active.isRemote():
                                     if self.active.dest.find('leo.phys.unm.edu') != -1:
                                         fsize = self.active.getFileSize()
-                                        with open('completed_%s.log' % self.dr, 'a') as fh:
-                                            fh.write('%.0f %s %s\n' % (time.time(), fsize, self.active.hostpath))
+                                        self.queue.add_completed(self.active.host,
+                                                                 self.active.hostpath,
+                                                                 fsize)
                                             
                             else:
                                 fsize = self.active.getFileSize()
-                                with open('completed_%s.log' % self.dr, 'a') as fh:
-                                    fh.write('%.0f %s %s\n' % (time.time(), fsize, self.active.hostpath))
-                                    
+                                self.queue.add_completed(self.active.host,
+                                                         self.active.hostpath,
+                                                         fsize)
+                                
                         elif self.active.isFailed():
                             ## No, but let's see we we can save it
                             if (not self.active.getFileExists()) or \
@@ -403,16 +405,14 @@ class ManageDR(object):
                                 ### Save it to the 'error' log
                                 fsize = self.active.getFileSize()
                                 with ell:
-                                    with open('error_%s.log' % self.dr, 'a') as fh:
-                                        fh.write('%.0f %s %s -> %s with %s\n' % (time.time(),
-                                                                                 fsize,
-                                                                                 self.active.hostpath,
-                                                                                 self.active.destpath,
-                                                                                 self.active.status))
-                                        
+                                    self.queue.add_failed(self.active.host,
+                                                          self.active.hostpath,
+                                                          self.getStats(),
+                                                          fsize)
+                                    
                             else:
                                 ### There's still a chance.  Stick it in again
-                                self.queue.put(self.active.getTaskSpecification())
+                                self.queue.put(*self.active.getTaskSpecification())
                                 
                         ### Check to see if this was a remote copy.  If so, 
                         ### we need to release the lock
@@ -426,6 +426,7 @@ class ManageDR(object):
                     # Try to clean things up on the DR
                     if time.time() - tLastPurge > 86400:
                         self.purgeCompleted()
+                        self.notifyFailures()
                         tLastPurge = time.time()
                         
                     # It looks like we can try to start another item in the queue running
@@ -443,7 +444,7 @@ class ManageDR(object):
                                     self.queue.task_done()
                                     
                                     ## Add it back in for later
-                                    self.queue.put(task)
+                                    self.queue.put(*task)
                                     time.sleep(5)
                                     continue
                                     
@@ -457,7 +458,7 @@ class ManageDR(object):
                                         self.queue.task_done()
                                         
                                         ## Add it back in for later
-                                        self.queue.put(task)
+                                        self.queue.put(*task)
                                         time.sleep(5)
                                         continue
                                     else:
@@ -488,7 +489,7 @@ class ManageDR(object):
         id = str( sng.get() )
         
         try:
-            self.queue.put( (host, hostpath, dest, destpath, id, 0, 0.0) )
+            self.queue.put(host, hostpath, dest, destpath, id, 0, 0.0)
             self.results[id] = 'queued for %s:%s -> %s:%s' % (host, hostpath, dest, destpath)
             return True,  id
         except Exception as e:
@@ -517,7 +518,7 @@ class ManageDR(object):
         
         try:
             dflag = DELETE_MARKER_NOW if now else DELETE_MARKER_QUEUE
-            self.queue.put( (host, hostpath, host, dflag, id, 0, 0.0) )
+            self.queue.put(host, hostpath, host, dflag, id, 0, 0.0)
             self.results[id] = 'queued delete for %s:%s' % (host, hostpath)
             return True,  id
         except Exception as e:
@@ -547,6 +548,18 @@ class ManageDR(object):
         """
         
         return True, 'active' if not self.inhibit else 'paused'
+        
+    def getQueueStats(self):
+        """
+        Return the queue stats.
+        """
+        
+        stats = self.queue.get_queue_stats()
+        report = ''
+        for key,value in stats.items():
+            report += f"{key}: {value}, "
+        report = report[:-2]
+        return True, report
         
     def getActiveID(self):
         """
@@ -617,50 +630,39 @@ class ManageDR(object):
         Purge completed transfers.
         """
         
-        # Get the name of the logfile to check
-        logname = 'completed_%s.log' % self.dr
-        
-        # Get how many lines are in the logfile
-        try:
-            totalSize = subprocess.check_output(['awk', "{sum+=$2} END {print sum}", logname], stderr=subprocess.DEVNULL)
-            totalSize = totalSize.decode()
-            totalSize = int(totalSize, 10)
-        except (subprocess.CalledProcessError, ValueError):
-            totalSize = 0
+        # Pull out all of the completed files and total up their size
+        completed = self.queue.get_completed()
+        totalSize = 0
+        for entry in completed:
+            totalSize += entry[2]
             
         # If we have at least 1 TB of files to cleanup, run the cleanup.  Otherwise, wait.
         if totalSize >= self.config['purge_size']*1024**4:
             smartThreadsLogger.info("Attempting to purge %.1f TB from %s", totalSize/1024.0**4, self.dr)
             
-            ## Run the cleanup
-            ### Load the files to purge
-            with open(logname, 'r') as fh:
-                lines = fh.read()
-            ### Zero out the purge list
-            os.unlink(logname)
-            
             ### Purge the files, keeping track of what we can't do and what has failed
             entries = lines.split('\n')[:-1]
             retry, failed = [], []
-            for entry in entries:
-                timestamp, fsize, filename = entry.split(None, 2)
+            for item in completed
+                host, filename, fsize = entry
                 try:
                     assert(not self.inhibit)
                     subprocess.check_output(['ssh', '-t', '-t', 'mcsdr@%s' % self.dr, 'shopt -s huponexit && sudo rm -f %s' % filename], stderr=subprocess.DEVNULL)
                     smartThreadsLogger.info('Removed %s:%s of size %s', self.dr, filename, fsize)
                 except AssertionError:
-                    retry.append( (timestamp, fsize, filename) )
+                    retry.append( (host, filename, fsize) )
                 except subprocess.CalledProcessError as e:
-                    failed.append( (timestamp, fsize, filename) )
+                    failed.append( (host, filename, fsize) )
                     smartThreadsLogger.warning('Failed to remove %s:%s of size %s', self.dr, filename, fsize)
                     smartThreadsLogger.debug('%s', str(e))
                     
+            self.queue.purge_completed()
+            
             ### If there are files that we were unable to transfer, save them for later
             if len(retry) > 0:
-                with open(logname, 'w') as fh:
-                    for timestamp,fsize,filename in retry:
-                        fh.write('%s %s %s\n' % (timestamp, fsize, filename))
-                        
+                for entry in retry:
+                    self.queue.add_completed(*entry)
+                    
                 return False
                 
             return True
@@ -668,155 +670,59 @@ class ManageDR(object):
         else:
             ## Skip the cleanup
             return False
-
-
-class MonitorErrorLogs(object):
-    def __init__(self, config):
-        self.config = config
-        
-        # Setup threading
-        self.thread = None
-        self.alive = threading.Event()
-        self.alive.clear()
-        self.lastError = None
-        
-        # Activity
-        self.active = None
-        self.thread = None
-        
-        # Setup e-mail access
-        ## SMTP user and password
-        self.FROM = self.config['email']['username']
-        self.PASS = self.config['email']['password']
-        self.ESRV = self.config['email']['smtp_server']
-        
-    def start(self):
+            
+    def notifyFailures(self):
         """
-        Start the station monitoring thread.
+        Send an email to note all of the copy/deletion failures
         """
         
-        if self.thread is not None:
-            self.stop()
-            
-        self.thread = threading.Thread(target=self.monitorLogs, name='monitorLogs')
-        self.thread.setDaemon(1)
-        self.alive.set()
-        self.thread.start()
-        time.sleep(1)
+        # Pull out all of the failed files
+        failed = self.queue.get_failed()
         
-        smartThreadsLogger.info('Started smart copy error log monitor')
-        
-    def stop(self):
-        """
-        Stop the station monitoring thread.
-        """
-        
-        if self.thread is not None:
-            self.alive.clear()          #clear alive event for thread
+        # Create a report on the failures
+        # Report 
+        report = ''
+        for entry in failed:
+            host, hostpath, reason, fsize = entry
+            report += f"  {hostpath} ({fsize} B) with {reason if reason else 'unknown'}\n"
             
-            self.thread.join()          #don't wait too long on the thread to finish
-            self.thread = None
-            self.lastError = None
-            
-            smartThreadsLogger.info('Stopped smart copy error log monitor')
-            
-    def monitorLogs(self):
-        # Checks run even later in the day (22:00 UTC)
-        tLastCheck = (int(time.time())/86400)*86400 + 22*3600
-        
-        while self.alive.isSet():
-            tStart = time.time()
-            
-            if tStart - tLastCheck >= 86400:
-                # Failure complination
-                failures = {}
+        # Send the report as an email, if there is anything to send
+        if len(report) > 0:
+            ## A copy for the logs
+            smartThreadsLogger.debug(f"{self.dr} Failures:")
+            for line in report.split('\n'):
+                smartThreadsLogger.debug(line)
                 
-                # Error logs
-                filenames = glob.glob('error_*.log')
-                filenames.sort()
-                for filename in filenames:
-                    ## DR name
-                    dr = os.path.basename(filename)
-                    dr = os.path.splitext(dr)[0]
-                    dr = dr.rsplit('_', 1)[1]
-                    
-                    ## Parse to figure out which lines to keep
-                    with ell:
-                        ### Load
-                        with open(filename, 'r') as fh:
-                            contents = fh.read()
-                            
-                        ### Sort
-                        to_keep = []
-                        for line in contents.split('\n'):
-                            if len(line) < 3:
-                                continue
-                            timestamp, fsize, dataname = line.split(None, 2)
-                            timestamp = int(timestamp, 10)
-                            fsize = int(fsize, 10)
-                            
-                            if timestamp >= tStart - 86400 - 3600:
-                                to_keep.append(line)
-                                
-                                if fsize > 0:
-                                    try:
-                                        failures[dr].append(dataname)
-                                    except KeyError:
-                                        failures[dr] = [dataname,]
-                                        
-                        ### Save
-                        with open(filename, 'w') as fh:
-                            fh.write('\n'.join(to_keep))
-                            
-                # Report 
-                report = ''
-                for dr in sorted(list(failures.keys())):
-                    report += '%s:\n' % dr
-                    for dataname in failures[dr]:
-                        report += '  %s\n' % dataname
-                        
-                # Send the report as an email, if there is anything to send
-                if len(report) > 0:
-                    ## A copy for the logs
-                    for line in report.split('\n'):
-                        smartThreadsLogger.debug("%s", line)
-                        
-                    ## Add on an "email ID" to get around list.unm.edu silliness
-                    report = "%s\n\nEmail ID: %s" % (report, str(uuid.uuid4()))
-                    
-                    ## The message itself
-                    ### Who gets it
-                    to = ['lwa1ops-l@list.unm.edu',]
-                    cc = None
-                    
-                    ### The report
-                    msg = MIMEText(report)
-                    msg['Subject'] = 'Recent SmartCopy Failures - %s' % (datetime.utcnow().strftime("%Y/%m/%d"),)
-                    msg['From'] = self.FROM
-                    msg['To'] = ','.join(to)
-                    if cc is not None:
-                        cc = list(set(cc))
-                        msg['Cc'] = ','.join(cc)
-                    msg.add_header('reply-to', 'lwa1ops-l@list.unm.edu')
-                    
-                    ### The other who gets it
-                    rcpt = []
-                    rcpt.extend(to)
-                    if cc is not None:
-                        rcpt.extend(cc)
-                        
-                    ## Send it off
-                    try:
-                        server = smtplib.SMTP(self.ESRV, 587)
-                        server.starttls()
-                        server.login(self.FROM, self.PASS)
-                        server.sendmail(self.FROM, rcpt, msg.as_string())
-                        server.close()
-                    except Exception as e:
-                        smartThreadsLogger.error("Could not send error report e-mail: %s", str(e))
-                        
-                # Update the last check time
-                tLastCheck = time.time()
+            ## Add on an "email ID" to get around list.unm.edu silliness
+            report = f"{report}\n\nEmail ID: {str(uuid.uuid4())}"
+            
+            ## The message itself
+            ### Who gets it
+            to = ['lwa1ops-l@list.unm.edu',]
+            cc = None
+            
+            ### The report
+            msg = MIMEText(report)
+            msg['Subject'] = 'Recent SmartCopy Failures  for %s - %s' % (self.dr, datetime.utcnow().strftime("%Y/%m/%d"),)
+            msg['From'] = self.FROM
+            msg['To'] = ','.join(to)
+            if cc is not None:
+                cc = list(set(cc))
+                msg['Cc'] = ','.join(cc)
+            msg.add_header('reply-to', 'lwa1ops-l@list.unm.edu')
+            
+            ### The other who gets it
+            rcpt = []
+            rcpt.extend(to)
+            if cc is not None:
+                rcpt.extend(cc)
                 
-            # Sleep
-            time.sleep(5)
+            ## Send it off
+            try:
+                server = smtplib.SMTP(self.ESRV, 587)
+                server.starttls()
+                server.login(self.FROM, self.PASS)
+                server.sendmail(self.FROM, rcpt, msg.as_string())
+                server.close()
+            except Exception as e:
+                smartThreadsLogger.error("Could not send error report e-mail: %s", str(e))

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -407,7 +407,7 @@ class ManageDR(object):
                                 with ell:
                                     self.queue.add_failed(self.active.host,
                                                           self.active.hostpath,
-                                                          self.getStats(),
+                                                          self.active.stderr,
                                                           fsize)
                                     
                             else:

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -641,9 +641,8 @@ class ManageDR(object):
             smartThreadsLogger.info("Attempting to purge %.1f TB from %s", totalSize/1024.0**4, self.dr)
             
             ### Purge the files, keeping track of what we can't do and what has failed
-            entries = lines.split('\n')[:-1]
             retry, failed = [], []
-            for item in completed:
+            for entry in completed:
                 host, filename, fsize = entry
                 try:
                     assert(not self.inhibit)

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -266,7 +266,7 @@ class ManageDR(object):
         self.config = config
         self.SCCallbackInstance = SCCallbackInstance
         
-        self.queue = DiskBackedQueue('.%s.queue' % self.dr, restore=True)
+        self.queue = DiskBackedQueue('smartcopy.db', queue_name=self.dr, restore=True)
         
         # Setup threading
         self.thread = None

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -643,7 +643,7 @@ class ManageDR(object):
             ### Purge the files, keeping track of what we can't do and what has failed
             entries = lines.split('\n')[:-1]
             retry, failed = [], []
-            for item in completed
+            for item in completed:
                 host, filename, fsize = entry
                 try:
                     assert(not self.inhibit)

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -683,7 +683,7 @@ class ManageDR(object):
         report = ''
         for entry in failed:
             host, hostpath, reason, fsize = entry
-            report += f"  {hostpath} ({fsize} B) with {reason if reason else 'unknown'}\n"
+            report += f" * {hostpath} ({fsize} B) with {reason if reason else 'unknown'}\n"
             
         # Send the report as an email, if there is anything to send
         if len(report) > 0:
@@ -702,7 +702,7 @@ class ManageDR(object):
             
             ### The report
             msg = MIMEText(report)
-            msg['Subject'] = 'Recent SmartCopy Failures  for %s - %s' % (self.dr, datetime.utcnow().strftime("%Y/%m/%d"),)
+            msg['Subject'] = '%s - Recent SmartCopy Failures for %s - %s' % (SITE.upper(), self.dr, datetime.utcnow().strftime("%Y/%m/%d"),)
             msg['From'] = self.config['email']['username']
             msg['To'] = ','.join(to)
             if cc is not None:
@@ -725,3 +725,5 @@ class ManageDR(object):
                 server.close()
             except Exception as e:
                 smartThreadsLogger.error("Could not send error report e-mail: %s", str(e))
+                
+            self.queue.purge_failed()

--- a/smartThreads.py
+++ b/smartThreads.py
@@ -280,7 +280,7 @@ class ManageDR(object):
         
         # Results cache
         self.results = LimitedSizeDict(size_limit=512)
-        for entry in self.queue.restored:
+        for entry in self.queue.restored_items:
             host, hostpath, dest, destpath, id, retries, lasttry = entry
             self.results[id] = 'queued for %s:%s -> %s:%s' % (host, hostpath, dest, destpath)
             

--- a/smart_cmnd.py
+++ b/smart_cmnd.py
@@ -406,27 +406,6 @@ def main(args):
         message_out_host = "10.1.3.2"
     nametag = SITE.replace('lwa', '').lower()
     
-    # Update the configuration and zeroconf
-    config['mcs']['message_out_host'] = message_out_host
-    try:
-        from zeroconf import Zeroconf, ServiceInfo
-        
-        zeroconf = Zeroconf()
-        
-        zconfig = {}
-        for key in config['mcs']:
-            zconfig[key] = str(config['mcs'][key])
-        
-        zinfo = ServiceInfo("_sccs%s._udp.local." % nametag, "Smart copy server._sccs%s._udp.local." % nametag, 
-                            port=config['mcs']['message_in_port'], weight=0, priority=0, 
-                            properties=zconfig, server="%s.local." % socket.gethostname(),
-                            addresses=[socket.inet_aton(config['mcs']['message_out_host']),])
-                    
-        zeroconf.register_service(zinfo)
-        
-    except ImportError:
-        logger.warning('Could not launch zeroconf service info')
-        
     # Setup SmartCopy control
     lwaSC = SmartCopy(config)
     
@@ -500,13 +479,6 @@ def main(args):
     refServer.stop()
     mcsComms.stop()
     
-    # Close down zeroconf
-    try:
-        zeroconf.unregister_service(zinfo)
-        zeroconf.close()
-    except NameError:
-        pass
-        
     # Exit
     logger.info('Finished')
     logging.shutdown()
@@ -526,4 +498,3 @@ if __name__ == "__main__":
                         help='print debug messages as well as info and higher')
     args = parser.parse_args()
     main(args)
-    

--- a/smart_cmnd.py
+++ b/smart_cmnd.py
@@ -157,7 +157,7 @@ class MCSCommunicate(Communicate):
                         else:
                             packed_data = self.SubSystemInstance.currentState['lastLog']
                             
-                    if prop == 'STATUS':
+                    elif prop == 'STATUS':
                         status, packed_data = self.SubSystemInstance.getDRQueueState(value)
                         if status:
                             packed_data = str(packed_data)

--- a/smart_cmnd.py
+++ b/smart_cmnd.py
@@ -132,7 +132,14 @@ class MCSCommunicate(Communicate):
                         else:
                             packed_data = self.SubSystemInstance.currentState['lastLog']
                             
-                    elif prop == 'STATUS':
+                    elif prop == 'STATS':
+                        status, packed_data = self.SubSystemInstance.getDRQueueStats(value)
+                        if status:
+                            packed_data = str(packed_data)
+                        else:
+                            packed_data = self.SubSystemInstance.currentState['lastLog']
+                            
+                    if prop == 'STATUS':
                         status, packed_data = self.SubSystemInstance.getDRQueueState(value)
                         if status:
                             packed_data = str(packed_data)


### PR DESCRIPTION
This PR moves SmartCopy over to using sqlite3 for its disk-backed queue.  This PR also cleans up the error handling for failed copies to make the underlying problem easier to trace.